### PR TITLE
add shallow option to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # go-bpu
+
 > Transform Bitcoin Transactions into Virtual Procedure Call Units (Bitcoin Processing Unit)
 
 ![bpu](./bpu.png)
@@ -42,7 +43,7 @@ View the generated [documentation](https://pkg.go.dev/github.com/bitcoinschema/g
 ### Split Config
 
 ```go
-var seperator = "|"
+var separator = "|"
 var l = bpu.IncludeL
 var opReturn = uint8(106)
 var opFalse = uint8(0)
@@ -62,7 +63,7 @@ var splitConfig = []SplitConfig{
 	},
 	{
 		Token: &Token{
-			S: &seperator,
+			S: &separator,
 		},
     Require: &opFalse,
 	},

--- a/bpu.go
+++ b/bpu.go
@@ -49,12 +49,12 @@ func (b *Tx) fromConfig(config ParseConfig) (err error) {
 	}
 
 	// convert all of the xputs to inputs
-	var inputs = make([]Input, 0, len(gene.Inputs))
+	var inputs = make([]Input, len(gene.Inputs))
 	inputs, err = processInputs(inXputs, gene.Inputs)
 	if err != nil {
 		return err
 	}
-	var outputs = make([]Output, 0, len(gene.Outputs))
+	var outputs = make([]Output, len(gene.Outputs))
 	outputs, err = processOutputs(outXputs, gene.Outputs)
 	if err != nil {
 		return err

--- a/bpu.go
+++ b/bpu.go
@@ -143,8 +143,10 @@ func processOutputs(outXputs []XPut, geneOutputs []*bt.Output) ([]Output, error)
 	return outputs, nil
 }
 
-// splits inputs and outputs into tapes where delimeters are found (defined by parse config)
-func collect(config ParseConfig, inputs []*bt.Input, outputs []*bt.Output) (xputIns []XPut, xputOuts []XPut, err error) {
+// splits inputs and outputs into tapes wherever
+// delimeters are found (defined by parse config)
+func collect(config ParseConfig, inputs []*bt.Input, outputs []*bt.Output) (
+	xputIns []XPut, xputOuts []XPut, err error) {
 	if config.Transform == nil {
 		config.Transform = &defaultTransform
 	}

--- a/bpu.go
+++ b/bpu.go
@@ -49,13 +49,12 @@ func (b *Tx) fromConfig(config ParseConfig) (err error) {
 	}
 
 	// convert all of the xputs to inputs
-	var inputs = make([]Input, len(gene.Inputs))
-	inputs, err = processInputs(inXputs, gene.Inputs)
+	inputs, err := processInputs(inXputs, gene.Inputs)
 	if err != nil {
 		return err
 	}
-	var outputs = make([]Output, len(gene.Outputs))
-	outputs, err = processOutputs(outXputs, gene.Outputs)
+
+	outputs, err := processOutputs(outXputs, gene.Outputs)
 	if err != nil {
 		return err
 	}

--- a/types.go
+++ b/types.go
@@ -34,7 +34,9 @@ type SplitConfig struct {
 type Mode string
 
 const (
-	Deep    Mode = "deep"
+	// Deep mode evalurates every pushdata regardless of quantity
+	Deep Mode = "deep"
+	// Shallow mode only evaluates the first 128 pushdata and the last 128 pushdatas
 	Shallow Mode = "shallow"
 )
 

--- a/xput.go
+++ b/xput.go
@@ -177,8 +177,8 @@ func (x *XPut) processScriptChunk(
 	h *string,
 	b *string,
 	chunkIndex uint8,
-	cell_i uint8,
-	tape_i uint8,
+	cellI uint8,
+	tapeI uint8,
 	hexStr string,
 ) (uint8, uint8, bool, error) {
 
@@ -190,49 +190,49 @@ func (x *XPut) processScriptChunk(
 		item, err = t(
 			Cell{Op: op, Ops: ops, S: s,
 				H: h,
-				B: b, II: chunkIndex, I: cell_i},
+				B: b, II: chunkIndex, I: cellI},
 			hexStr,
 		)
 	} else {
 		item, err = t(
-			Cell{B: b, S: s, H: h, II: chunkIndex, I: cell_i},
+			Cell{B: b, S: s, H: h, II: chunkIndex, I: cellI},
 			hexStr,
 		)
 	}
 
 	if err != nil {
-		return tape_i, cell_i, false, err
+		return tapeI, cellI, false, err
 	}
 
-	cell_i++
+	cellI++
 	if len(x.Tape) == 0 {
 		// create a new tape including the cell
 		cell = append(cell, *item)
-		outTape := append(x.Tape, Tape{Cell: cell, I: cell_i})
+		outTape := append(x.Tape, Tape{Cell: cell, I: cellI})
 		x.Tape = outTape
 	} else {
 
 		// create new tape if needed
-		if len(x.Tape) == int(tape_i) {
+		if len(x.Tape) == int(tapeI) {
 			x.Tape = append(x.Tape, Tape{
-				I:    tape_i,
+				I:    tapeI,
 				Cell: make([]Cell, 0),
 			})
 		}
 
-		cell = append(x.Tape[tape_i].Cell, *item)
+		cell = append(x.Tape[tapeI].Cell, *item)
 
 		// add the cell to the tape
-		x.Tape[tape_i].Cell = cell
+		x.Tape[tapeI].Cell = cell
 	}
-	return tape_i, cell_i, false, nil
+	return tapeI, cellI, false, nil
 }
 
 // process script chunk (splitter)
 func (x *XPut) processSplitterChunk(
 	o ParseConfig,
 	splitter *IncludeType,
-	cell_i uint8,
+	cellI uint8,
 	isOpType bool,
 	op *uint8,
 	ops *string,
@@ -240,7 +240,7 @@ func (x *XPut) processSplitterChunk(
 	h *string,
 	b *string,
 	chunkIndex uint8,
-	tape_i uint8,
+	tapeI uint8,
 	hexStr string,
 ) (uint8, uint8, bool, error) {
 	var err error
@@ -248,10 +248,10 @@ func (x *XPut) processSplitterChunk(
 	cell := make([]Cell, 0)
 	var item *Cell
 	if splitter == nil {
-		// Don't include the seperator by default, just make a new tape and reset cell
+		// Don't include the separator by default, just make a new tape and reset cell
 		// cell = make([]Cell, 0)
-		cell_i = 0
-		// tape_i++
+		cellI = 0
+		// tapeI++
 
 	} else if *splitter == IncludeL {
 		if isOpType {
@@ -262,7 +262,7 @@ func (x *XPut) processSplitterChunk(
 				S:   s,
 				H:   h,
 				B:   b,
-				I:   cell_i,
+				I:   cellI,
 				II:  chunkIndex,
 			}, hexStr)
 		} else {
@@ -270,73 +270,73 @@ func (x *XPut) processSplitterChunk(
 				S:  s,
 				B:  b,
 				H:  h,
-				I:  cell_i,
+				I:  cellI,
 				II: chunkIndex,
 			}, hexStr)
 		}
 		if err != nil {
-			return tape_i, cell_i, false, err
+			return tapeI, cellI, false, err
 		}
 
 		cell = append(cell, *item)
-		cell_i++
+		cellI++
 
 		// if theres an existing tape, add item to it...
 		if len(x.Tape) > 0 {
 			x.Tape[len(x.Tape)-1].Cell = append(x.Tape[len(x.Tape)-1].Cell, cell...)
 		} else {
 			// otherwise make a new tape
-			outTapes := append(x.Tape, Tape{Cell: cell, I: tape_i})
+			outTapes := append(x.Tape, Tape{Cell: cell, I: tapeI})
 			x.Tape = outTapes
-			// tape_i++
+			// tapeI++
 		}
 
-		cell_i = 0
+		cellI = 0
 		// cell = make([]Cell, 0)
 	} else if *splitter == IncludeC {
-		outTapes := append(x.Tape, Tape{Cell: cell, I: tape_i})
+		outTapes := append(x.Tape, Tape{Cell: cell, I: tapeI})
 		x.Tape = outTapes
-		//tape_i++
+		//tapeI++
 		// item, err := t(Cell{
 		// 	Op:  op,
 		// 	Ops: ops,
 		// 	S:   s,
 		// 	H:   h,
 		// 	B:   b,
-		// 	I:   cell_i,
+		// 	I:   cellI,
 		// 	II:  chunkIndex,
 		// }, hexStr)
 		// if err != nil {
-		// 	return tape_i, cell_i, false, err
+		// 	return tapeI, cellI, false, err
 		// }
 
 		// cell = []Cell{*item}
-		cell_i = 1
+		cellI = 1
 	} else if *splitter == IncludeR {
-		outTapes := append(x.Tape, Tape{Cell: cell, I: tape_i})
+		outTapes := append(x.Tape, Tape{Cell: cell, I: tapeI})
 		x.Tape = outTapes
-		//tape_i++
+		//tapeI++
 		item, err := t(Cell{
 			Op:  op,
 			Ops: ops,
 			S:   s,
 			H:   h,
 			B:   b,
-			I:   cell_i,
+			I:   cellI,
 			II:  chunkIndex,
 		}, hexStr)
 		if err != nil {
-			return tape_i, cell_i, false, err
+			return tapeI, cellI, false, err
 		}
 
 		cell = []Cell{*item}
-		outTapes = append(outTapes, Tape{Cell: cell, I: tape_i})
+		outTapes = append(outTapes, Tape{Cell: cell, I: tapeI})
 		x.Tape = outTapes
 
 		//cell = make([]Cell, 0)
-		cell_i = 0
+		cellI = 0
 	}
 
-	return tape_i, cell_i, true, nil
+	return tapeI, cellI, true, nil
 
 }

--- a/xput.go
+++ b/xput.go
@@ -279,7 +279,7 @@ func (x *XPut) processSplitterChunk(
 		}
 
 		cell = append(cell, *item)
-		cellI++
+		//cellI++
 
 		// if theres an existing tape, add item to it...
 		if len(x.Tape) > 0 {


### PR DESCRIPTION
shallow option takes first 128 pushdatas and last 128 pushdatas and uses only that data omitting everything else. not relevant to 99% of txs but huge performance gain to the ones who have massive number of pushdata while retaining flexible and unrestrictive limitations.