### PR TITLE
fix: handle invalid script data after OP_RETURN in DecodeScript

### DIFF
--- a/bpu_test.go
+++ b/bpu_test.go
@@ -217,7 +217,7 @@ func TestDecodeParts(t *testing.T) {
 	gene, err := transaction.NewTransactionFromHex(testnetInvalidOpcode)
 	assert.Nil(t, err)
 	scr := gene.Outputs[0].LockingScript
-	parts, err := script.DecodeScript(*scr)
+	parts, err := script.DecodeScript(*scr, script.DecodeOptionsParseOpReturn)
 	assert.Nil(t, err)
 	assert.Equal(t, 999640, len(parts))
 }

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,9 @@
 module github.com/bitcoinschema/go-bpu
 
-go 1.24.0
-
-toolchain go1.24.1
+go 1.24.3
 
 require (
-	github.com/bsv-blockchain/go-sdk v1.1.27
+	github.com/bsv-blockchain/go-sdk v1.2.18
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -13,6 +11,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/crypto v0.45.0 // indirect
+	golang.org/x/crypto v0.47.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/bsv-blockchain/go-sdk v1.1.27 h1:N7IGPvOLh4YpMGJLGmPj+6PabwI06x8tX4ZJ5u4rrp4=
-github.com/bsv-blockchain/go-sdk v1.1.27/go.mod h1:d0HXzhHy21t+7z+LBpDhGyJSBJb8S5HiAmHsBtRKddQ=
+github.com/bsv-blockchain/go-sdk v1.2.18 h1:JFl8TNM7lf80CslrXjlungDOyuvL9COzond9BOR81Us=
+github.com/bsv-blockchain/go-sdk v1.2.18/go.mod h1:QWYwia7QSPB8+sLWyVldsIg0wPPzvEmXL5wGAT0dgaA=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -8,8 +8,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
-golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
+golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
+golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/xput.go
+++ b/xput.go
@@ -17,9 +17,9 @@ func (x *XPut) fromScript(config ParseConfig, scrpt *script.Script, idx uint8) e
 
 	if scrpt != nil {
 
-		parts, err := script.DecodeScript(*scrpt)
+		parts, err := script.DecodeScript(*scrpt, script.DecodeOptionsParseOpReturn)
 		if err != nil {
-			return err
+			return nil //nolint:nilerr // intentional: unparseable scripts produce an empty XPut
 		}
 		requireMet := make(map[int]bool)
 		splitterRequirementMet := make(map[int]bool)


### PR DESCRIPTION
## Summary

- Passes `DecodeOptionsParseOpReturn` to `script.DecodeScript` in `xput.go` so OP_RETURN data is parsed correctly
- Returns `nil` instead of propagating error when `DecodeScript` fails on unparseable output scripts (e.g. sCrypt contracts, non-standard OP_RETURN data)
- Bumps go-sdk from v1.1.27 to v1.2.18 (which introduced `DecodeOptionsParseOpReturn`)

## Problem

Transaction `471442b27852e6a1a83e2f2bec8c1712ad3721534f2e35fda89b853471e7898f` crashes the parsing pipeline. It contains an sCrypt contract output and a non-standard OP_RETURN output with invalid push data encoding. Without `DecodeOptionsParseOpReturn`, `DecodeScript` doesn't attempt to parse OP_RETURN data at all. With it enabled, when the post-OP_RETURN bytes can't be decoded, we now return nil so that:

1. The unparseable output still flows through with metadata (satoshis, address, index) but empty tapes
2. Other outputs in the same transaction parse normally
3. The entire transaction is not killed by one bad output